### PR TITLE
Legg til retry-statuser og feilmelding-felt for sed journalstatus

### DIFF
--- a/eux-nav-rinasak-model/src/main/kotlin/no/nav/eux/rinasak/model/entity/SedJournalstatus.kt
+++ b/eux-nav-rinasak-model/src/main/kotlin/no/nav/eux/rinasak/model/entity/SedJournalstatus.kt
@@ -14,6 +14,7 @@ data class SedJournalstatus(
     val sedVersjon: Int,
     @Enumerated(EnumType.STRING)
     val status: Status,
+    val feilmelding: String? = null,
     val endretBruker: String = "ukjent",
     val endretTidspunkt: LocalDateTime = now(),
     @Column(updatable = false)
@@ -28,6 +29,8 @@ data class SedJournalstatus(
         FEILREGISTRERT,
         KORRUPT,
         MELOSYS_JOURNALFOERER,
-        MANUELL_JOURNALFOERING
+        MANUELL_JOURNALFOERING,
+        FEILET_FERDIGSTILL,
+        FEILET_FEILREGISTRER
     }
 }

--- a/eux-nav-rinasak-openapi/src/main/resources/static/properties/dokument.yaml
+++ b/eux-nav-rinasak-openapi/src/main/resources/static/properties/dokument.yaml
@@ -33,6 +33,8 @@ sedJournalstatus:
     - KORRUPT
     - MELOSYS_JOURNALFOERER
     - MANUELL_JOURNALFOERING
+    - FEILET_FERDIGSTILL
+    - FEILET_FEILREGISTRER
   description: |
     Hvilken status det er på journalføringen til SED'en:
       * `JOURNALFOERT` - Journalposten tilhørende SED'en er journalført
@@ -41,3 +43,10 @@ sedJournalstatus:
       * `FEILREGISTRERT` - Journalposten tilhørende SED'en er feilregistrert
       * `MELOSYS_JOURNALFOERER` - Melosys håndterer journalføring av SED'en
       * `MANUELL_JOURNALFOERING` - Journalføring gjøres manuelt av saksbehandler
+      * `FEILET_FERDIGSTILL` - Ferdigstilling av journalpost feilet, planlagt for nytt forsøk
+      * `FEILET_FEILREGISTRER` - Feilregistrering av journalpost feilet, planlagt for nytt forsøk
+
+feilmelding:
+  type: string
+  description: >
+    Feilmelding fra siste forsøk på ferdigstilling eller feilregistrering av journalpost.

--- a/eux-nav-rinasak-openapi/src/main/resources/static/sed/model.yaml
+++ b/eux-nav-rinasak-openapi/src/main/resources/static/sed/model.yaml
@@ -19,6 +19,8 @@ SedJournalstatusType:
       $ref: '../properties/dokument.yaml#/sedVersjon'
     sedJournalstatus:
       $ref: '../properties/dokument.yaml#/sedJournalstatus'
+    feilmelding:
+      $ref: '../properties/dokument.yaml#/feilmelding'
     endretBruker:
       $ref: '../properties/meta.yaml#/endretBruker'
     endretTidspunkt:
@@ -44,6 +46,8 @@ SedJournalstatusCreateType:
       $ref: '../properties/dokument.yaml#/sedVersjon'
     sedJournalstatus:
       $ref: '../properties/dokument.yaml#/sedJournalstatus'
+    feilmelding:
+      $ref: '../properties/dokument.yaml#/feilmelding'
 
 SedJournalstatusPatchType:
   type: object
@@ -58,6 +62,8 @@ SedJournalstatusPatchType:
       $ref: '../properties/dokument.yaml#/sedVersjon'
     sedJournalstatus:
       $ref: '../properties/dokument.yaml#/sedJournalstatus'
+    feilmelding:
+      $ref: '../properties/dokument.yaml#/feilmelding'
 
 SedJournalstatusPutType:
   type: object
@@ -75,6 +81,8 @@ SedJournalstatusPutType:
       $ref: '../properties/dokument.yaml#/sedVersjon'
     sedJournalstatus:
       $ref: '../properties/dokument.yaml#/sedJournalstatus'
+    feilmelding:
+      $ref: '../properties/dokument.yaml#/feilmelding'
 
 SedJournalstatusSearchCriteriaType:
   type: object

--- a/eux-nav-rinasak-persistence/src/main/resources/db/migration/V10__sed_journalstatus_feilmelding.sql
+++ b/eux-nav-rinasak-persistence/src/main/resources/db/migration/V10__sed_journalstatus_feilmelding.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sed_journalstatus ADD COLUMN feilmelding TEXT;

--- a/eux-nav-rinasak-service/src/main/kotlin/no/nav/eux/rinasak/service/SedJournalstatusService.kt
+++ b/eux-nav-rinasak-service/src/main/kotlin/no/nav/eux/rinasak/service/SedJournalstatusService.kt
@@ -22,13 +22,14 @@ class SedJournalstatusService(
         sedId: UUID,
         sedVersjon: Int,
         status: SedJournalstatus.Status,
+        feilmelding: String? = null,
     ) {
         val current = repository
             .findBySedIdAndSedVersjon(sedId, sedVersjon)
             .firstOrNull()
         when {
-            current == null -> create(rinasakId, sedId, sedVersjon, status)
-            else -> repository.save(current.copy(status = status))
+            current == null -> create(rinasakId, sedId, sedVersjon, status, feilmelding)
+            else -> repository.save(current.copy(status = status, feilmelding = feilmelding))
         }
         log.info { "Sed journalstatus satt til $status" }
     }
@@ -56,6 +57,7 @@ class SedJournalstatusService(
         sedId: UUID,
         sedVersjon: Int,
         status: SedJournalstatus.Status,
+        feilmelding: String? = null,
     ) {
         repository.save(
             SedJournalstatus(
@@ -64,6 +66,7 @@ class SedJournalstatusService(
                 sedId = sedId,
                 sedVersjon = sedVersjon,
                 status = status,
+                feilmelding = feilmelding,
                 opprettetBruker = contextService.navIdent,
                 endretBruker = contextService.navIdent
             )

--- a/eux-nav-rinasak-webapp/src/main/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusApiImpl.kt
+++ b/eux-nav-rinasak-webapp/src/main/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusApiImpl.kt
@@ -27,6 +27,7 @@ class SedJournalstatusApiImpl(
                 sedId = sedJournalstatusPutType.sedId,
                 sedVersjon = sedJournalstatusPutType.sedVersjon,
                 status = sedJournalstatusPutType.sedJournalstatus.name.toEnum(),
+                feilmelding = sedJournalstatusPutType.feilmelding,
             )
             .toOkResponseEntity()
 

--- a/eux-nav-rinasak-webapp/src/main/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusMapper.kt
+++ b/eux-nav-rinasak-webapp/src/main/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusMapper.kt
@@ -21,6 +21,7 @@ fun SedJournalstatus.toSedJournalstatus() =
         sedId = sedId,
         sedVersjon = sedVersjon,
         sedJournalstatus = status.name.toEnum(),
+        feilmelding = feilmelding,
         endretBruker = endretBruker,
         endretTidspunkt = endretTidspunkt.atOffset(UTC),
         opprettetBruker = opprettetBruker,

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusApiTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusApiTest.kt
@@ -146,4 +146,105 @@ class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
         )
         response.statusCode.value() shouldBe 400
     }
+
+    @Test
+    fun `PUT sed journalstatuser med feilmelding - forespørsel, finn med id - 200`() {
+        val createResponse = restTemplate.exchange<Void>(
+            url = sedJournalstatuserUrl,
+            method = HttpMethod.PUT,
+            requestEntity = SedJournalstatusPutTestModel(
+                rinasakId = 1,
+                sedId = uuid1,
+                sedVersjon = 1,
+                sedJournalstatus = "FEILET_FERDIGSTILL",
+                feilmelding = "Ferdigstilling feilet: 500 Internal Server Error"
+            )
+                .httpEntity
+        )
+        createResponse.statusCode.value() shouldBe 200
+        val sedJournalstatus = restTemplate
+            .postForObject<SedJournalstatuserTestModel>(
+                url = sedJournalstatuserFinnUrl,
+                request = SedJournalstatusFinnKriterierTestModel(
+                    sedId = uuid1,
+                    sedVersjon = 1
+                )
+                    .httpEntity
+            )!!
+            .sedJournalstatuser
+            .single()
+        sedJournalstatus.rinasakId shouldBe 1
+        sedJournalstatus.sedId shouldBe uuid1
+        sedJournalstatus.sedVersjon shouldBe 1
+        sedJournalstatus.sedJournalstatus shouldBe "FEILET_FERDIGSTILL"
+        sedJournalstatus.feilmelding shouldBe "Ferdigstilling feilet: 500 Internal Server Error"
+    }
+
+    @Test
+    fun `PUT sed journalstatuser uten feilmelding - feilmelding er null - 200`() {
+        val createResponse = restTemplate.exchange<Void>(
+            url = sedJournalstatuserUrl,
+            method = HttpMethod.PUT,
+            requestEntity = SedJournalstatusPutTestModel(
+                rinasakId = 1,
+                sedId = uuid1,
+                sedVersjon = 1,
+                sedJournalstatus = "UKJENT"
+            )
+                .httpEntity
+        )
+        createResponse.statusCode.value() shouldBe 200
+        val sedJournalstatus = restTemplate
+            .postForObject<SedJournalstatuserTestModel>(
+                url = sedJournalstatuserFinnUrl,
+                request = SedJournalstatusFinnKriterierTestModel(
+                    sedId = uuid1,
+                    sedVersjon = 1
+                )
+                    .httpEntity
+            )!!
+            .sedJournalstatuser
+            .single()
+        sedJournalstatus.feilmelding shouldBe null
+    }
+
+    @Test
+    fun `PUT sed journalstatuser - oppdater eksisterende med feilmelding - 200`() {
+        restTemplate.exchange<Void>(
+            url = sedJournalstatuserUrl,
+            method = HttpMethod.PUT,
+            requestEntity = SedJournalstatusPutTestModel(
+                rinasakId = 1,
+                sedId = uuid1,
+                sedVersjon = 1,
+                sedJournalstatus = "UKJENT"
+            )
+                .httpEntity
+        )
+        restTemplate.exchange<Void>(
+            url = sedJournalstatuserUrl,
+            method = HttpMethod.PUT,
+            requestEntity = SedJournalstatusPutTestModel(
+                rinasakId = 1,
+                sedId = uuid1,
+                sedVersjon = 1,
+                sedJournalstatus = "FEILET_FERDIGSTILL",
+                feilmelding = "Ferdigstilling feilet: 500 Internal Server Error"
+            )
+                .httpEntity
+        )
+        val sedJournalstatus = restTemplate
+            .postForObject<SedJournalstatuserTestModel>(
+                url = sedJournalstatuserFinnUrl,
+                request = SedJournalstatusFinnKriterierTestModel(
+                    sedId = uuid1,
+                    sedVersjon = 1
+                )
+                    .httpEntity
+            )!!
+            .sedJournalstatuser
+            .single()
+        sedJournalstatus.sedJournalstatus shouldBe "FEILET_FERDIGSTILL"
+        sedJournalstatus.feilmelding shouldBe "Ferdigstilling feilet: 500 Internal Server Error"
+    }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/model/base/SedJournalstatusPutTestModel.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/model/base/SedJournalstatusPutTestModel.kt
@@ -4,5 +4,6 @@ data class SedJournalstatusPutTestModel(
     val rinasakId: Int,
     val sedId: java.util.UUID,
     val sedVersjon: Int,
-    val sedJournalstatus: String
+    val sedJournalstatus: String,
+    val feilmelding: String? = null,
 )

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/model/base/SedJournalstatusTestModel.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/model/base/SedJournalstatusTestModel.kt
@@ -8,6 +8,7 @@ data class SedJournalstatusTestModel(
     val sedId: UUID,
     val sedVersjon: Int,
     val sedJournalstatus: String,
+    val feilmelding: String?,
     val endretBruker: String,
     val endretTidspunkt: LocalDateTime,
     val opprettetBruker: String,


### PR DESCRIPTION
## Endringer

Implementerer #22 — støtte for retry-mekanisme i sed journalstatus.

### Nye enum-verdier
- `FEILET_FERDIGSTILL` — Ferdigstilling av journalpost feilet, planlagt for nytt forsøk
- `FEILET_FEILREGISTRER` — Feilregistrering av journalpost feilet, planlagt for nytt forsøk

### Nytt felt
- `feilmelding: String?` — valgfritt tekstfelt for feilbeskrivelse fra siste forsøk

### Endrede filer
- **OpenAPI spec** — nye enum-verdier og `feilmelding` i alle SED DTOs
- **Entity** — `feilmelding` og nye statuser
- **Flyway V10** — `ALTER TABLE sed_journalstatus ADD COLUMN feilmelding TEXT`
- **Service/Mapper/Controller** — propagerer `feilmelding` gjennom alle lag
- **Tester** — 3 nye tester (opprettelse med feilmelding, null-verdi, oppdatering)

### Bakoverkompatibilitet
- Alle nye felt er nullable/optional — ingen breaking changes
- Nye enum-verdier settes kun av eux-journalarkivar etter denne deployen

Closes #22