### PR TITLE
Migrate from TestRestTemplate to RestTestClient

### DIFF
--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/AbstractRinasakerApiImplTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/AbstractRinasakerApiImplTest.kt
@@ -1,19 +1,16 @@
 package no.nav.eux.rinasak.webapp
 
 import no.nav.eux.rinasak.Application
-import no.nav.eux.rinasak.webapp.common.httpEntity
-import no.nav.eux.rinasak.webapp.common.voidHttpEntity
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.resttestclient.TestRestTemplate
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpEntity
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.jdbc.JdbcTestUtils
+import org.springframework.test.web.servlet.client.RestTestClient
 
 @SpringBootTest(
     classes = [Application::class],
@@ -21,14 +18,14 @@ import org.springframework.test.jdbc.JdbcTestUtils
 )
 @ActiveProfiles("test")
 @EnableMockOAuth2Server
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 abstract class AbstractRinasakerApiImplTest {
 
     @Autowired
     lateinit var mockOAuth2Server: MockOAuth2Server
 
     @Autowired
-    lateinit var restTemplate: TestRestTemplate
+    lateinit var restTestClient: RestTestClient
 
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
@@ -44,10 +41,5 @@ abstract class AbstractRinasakerApiImplTest {
             "sed_journalstatus"
         )
     }
-
-    fun httpEntity() = voidHttpEntity(mockOAuth2Server)
-
-    val <T : Any> T.httpEntity: HttpEntity<T>
-        get() = httpEntity(mockOAuth2Server)
 
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiDokumentOpprettelseTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiDokumentOpprettelseTest.kt
@@ -3,6 +3,7 @@ package no.nav.eux.rinasak.webapp
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerFinnUrl
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.common.uuid1
 import no.nav.eux.rinasak.webapp.common.uuid4
 import no.nav.eux.rinasak.webapp.dataset.oppdatering.navRinasakDokumentOpprettelse
@@ -10,30 +11,27 @@ import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
 import no.nav.eux.rinasak.webapp.model.base.NavRinasakFinnKriterier
 import no.nav.eux.rinasak.webapp.model.base.NavRinasaker
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.boot.resttestclient.postForObject
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 
 class RinasakerApiDokumentOpprettelseTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker dokumenter - gyldig forespørsel - 201`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val createResponse = restTemplate.postForEntity<Void>(
-            "$navRinasakerUrl/1/dokumenter",
-            navRinasakDokumentOpprettelse.httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 201
-        val navRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        restTestClient.post().uri("$navRinasakerUrl/1/dokumenter")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakDokumentOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val navRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         val dokumentMap = navRinasak.dokumenter!!.associateBy { Pair(it.sedId, it.sedVersjon) }
@@ -53,22 +51,20 @@ class RinasakerApiDokumentOpprettelseTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker dokumenter - ikke autentisert - 401`() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        val entity = HttpEntity<String>("{}", headers)
-        val createResponse = restTemplate.postForEntity<Void>(
-            "$navRinasakerUrl/1/dokumenter",
-            entity
-        )
-        createResponse.statusCode.value() shouldBe 401
+        restTestClient.post().uri("$navRinasakerUrl/1/dokumenter")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .exchange()
+            .expectStatus().isEqualTo(401)
     }
 
     @Test
     fun `POST rinasaker dokumenter - ugyldig request - 400`() {
-        val createResponse = restTemplate.postForEntity<Void>(
-            "$navRinasakerUrl/1/dokumenter",
-            ".".httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 400
+        restTestClient.post().uri("$navRinasakerUrl/1/dokumenter")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(".")
+            .exchange()
+            .expectStatus().isEqualTo(400)
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiFinnRinasakTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiFinnRinasakTest.kt
@@ -2,33 +2,26 @@ package no.nav.eux.rinasak.webapp
 
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.common.uuid1
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
 import no.nav.eux.rinasak.webapp.model.base.NavRinasak
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpMethod.GET
-import org.springframework.http.MediaType
 
 class RinasakerApiFinnRinasakTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `GET rinasaker - forespørsel, finn med id - 200`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val entity = restTemplate.exchange(
-            "/api/v1/rinasaker/1",
-            GET,
-            httpEntity(),
-            NavRinasak::class.java
-        )
-        entity.statusCode.value() shouldBe 200
-        val navRinasak = entity.body!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        val navRinasak = restTestClient.get().uri("/api/v1/rinasaker/1")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(NavRinasak::class.java)
+            .returnResult().responseBody!!
         navRinasak.rinasakId shouldBe 1
         navRinasak.overstyrtEnhetsnummer shouldBe "1234"
         with(navRinasak.initiellFagsak!!) {
@@ -50,23 +43,16 @@ class RinasakerApiFinnRinasakTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `GET rinasaker - forespørsel, ikke funnet - 404`() {
-        val entity = restTemplate.exchange<Void>(
-            url = "/api/v1/rinasaker/2",
-            method = GET,
-            requestEntity = httpEntity()
-        )
-        entity.statusCode.value() shouldBe 404
+        restTestClient.get().uri("/api/v1/rinasaker/2")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectStatus().isEqualTo(404)
     }
 
     @Test
     fun `GET rinasaker finn - ikke autentisert - 401`() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        val entity = restTemplate.exchange<Void>(
-            url = "/api/v1/rinasaker/1",
-            method = GET,
-            requestEntity = HttpEntity<Void>(headers)
-        )
-        entity.statusCode.value() shouldBe 401
+        restTestClient.get().uri("/api/v1/rinasaker/1")
+            .exchange()
+            .expectStatus().isEqualTo(401)
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiFinnTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiFinnTest.kt
@@ -2,42 +2,38 @@ package no.nav.eux.rinasak.webapp
 
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerFinnUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.model.base.NavRinasakFinnKriterier
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 
 class RinasakerApiFinnTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker finn - finn uten kriterier - 200`() {
-        val response = restTemplate.postForEntity<Void>(
-            navRinasakerFinnUrl,
-            NavRinasakFinnKriterier().httpEntity
-        )
-        response.statusCode.value() shouldBe 200
+        restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier())
+            .exchange()
+            .expectStatus().isEqualTo(200)
     }
 
     @Test
     fun `POST rinasaker finn - ikke autentisert - 401`() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        val entity = HttpEntity<String>("{}", headers)
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerFinnUrl,
-            entity
-        )
-        createResponse.statusCode.value() shouldBe 401
+        restTestClient.post().uri(navRinasakerFinnUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .exchange()
+            .expectStatus().isEqualTo(401)
     }
 
     @Test
     fun `POST rinasaker finn - ugyldig request - 400`() {
-        val finnResponse = restTemplate.postForEntity<Void>(
-            navRinasakerFinnUrl,
-            ".".httpEntity
-        )
-        finnResponse.statusCode.value() shouldBe 400
+        restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(".")
+            .exchange()
+            .expectStatus().isEqualTo(400)
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiOppdateringTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiOppdateringTest.kt
@@ -2,52 +2,43 @@ package no.nav.eux.rinasak.webapp
 
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.dataset.oppdatering.navRinasakOppdatering
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 
 class RinasakerApiOppdateringTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PATCH rinasaker - gyldig forespørsel - 201`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val createResponse = restTemplate.exchange<Void>(
-            url = navRinasakerUrl,
-            method = HttpMethod.PATCH,
-            requestEntity = navRinasakOppdatering.httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 201
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        restTestClient.patch().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOppdatering)
+            .exchange()
+            .expectStatus().isEqualTo(201)
     }
 
     @Test
     fun `PATCH rinasaker - ikke autentisert - 401`() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        val entity = HttpEntity("{}", headers)
-        val createResponse = restTemplate.exchange<Void>(
-            url = navRinasakerUrl,
-            method = HttpMethod.PATCH,
-            requestEntity = entity
-        )
-        createResponse.statusCode.value() shouldBe 401
+        restTestClient.patch().uri(navRinasakerUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .exchange()
+            .expectStatus().isEqualTo(401)
     }
 
     @Test
     fun `PATCH rinasaker - ugyldig request - 400`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = navRinasakerUrl,
-            method = HttpMethod.PATCH,
-            requestEntity =  ".".httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 400
+        restTestClient.patch().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(".")
+            .exchange()
+            .expectStatus().isEqualTo(400)
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiOpprettelseTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiOpprettelseTest.kt
@@ -2,56 +2,51 @@ package no.nav.eux.rinasak.webapp
 
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.MediaType
 
 class RinasakerApiOpprettelseTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker - gyldig forespørsel - 201`() {
-            val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        createResponse.statusCode shouldBe CREATED
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+            .expectStatus().isCreated
     }
 
     @Test
     fun `POST rinasaker - finnes alt, conflict - 409`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 409
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(409)
     }
 
     @Test
     fun `POST rinasaker - ikke autentisert - 401`() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        val entity = HttpEntity<String>("{}", headers)
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            entity
-        )
-        createResponse.statusCode.value() shouldBe 401
+        restTestClient.post().uri(navRinasakerUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .exchange()
+            .expectStatus().isEqualTo(401)
     }
 
     @Test
     fun `POST rinasaker - ugyldig request - 400`() {
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            ".".httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 400
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(".")
+            .exchange()
+            .expectStatus().isEqualTo(400)
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerFinnUrl
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.common.uuid1
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelseEnkel1
@@ -15,24 +16,22 @@ import no.nav.eux.rinasak.webapp.model.base.NavRinasaker
 import no.nav.eux.rinasak.webapp.model.opprettelse.FagsakOpprettelse
 import no.nav.eux.rinasak.webapp.model.opprettelse.NavRinasakOpprettelse
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.boot.resttestclient.postForObject
-import org.springframework.http.HttpMethod
 
 class RinasakerApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker - forespørsel, finn med id - 200`() {
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 201
-        val navRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val navRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         navRinasak.rinasakId shouldBe 1
@@ -56,16 +55,17 @@ class RinasakerApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker - forespørsel, uten fagsak og sed finn med id - 200`() {
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            NavRinasakOpprettelse(initiellFagsak = null).httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 201
-        val navRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakOpprettelse(initiellFagsak = null))
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val navRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         navRinasak.rinasakId shouldBe 1
@@ -74,39 +74,41 @@ class RinasakerApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker finn - forespørsel, ikke funnet med feil id - 200`() {
-        val createResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 201
-        val navRinasaker = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 0).httpEntity
-            )!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val navRinasaker = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 0))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
         navRinasaker.shouldBeEmpty()
     }
 
     @Test
     fun `POST rinasaker finn - forespørsel, 3 enkle, hent ved rinasakId - 200`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelseEnkel1.httpEntity
-        )
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelseEnkel2.httpEntity
-        )
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelseEnkel3.httpEntity
-        )
-        val navRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 2).httpEntity
-            )!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelseEnkel1)
+            .exchange()
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelseEnkel2)
+            .exchange()
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelseEnkel3)
+            .exchange()
+        val navRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 2))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         navRinasak.rinasakId shouldBe 2
@@ -115,11 +117,11 @@ class RinasakerApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PATCH rinasaker fagsak - update existing fagsak - 201`() {
-        val createRinasakResponse = restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            NavRinasakOpprettelse(initiellFagsak = null).httpEntity
-        )
-        createRinasakResponse.statusCode.value() shouldBe 201
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakOpprettelse(initiellFagsak = null))
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val initialFagsakOpprettelse = FagsakOpprettelse(
             tema = "AAA",
             type = "FAGSAK",
@@ -127,18 +129,17 @@ class RinasakerApiTest : AbstractRinasakerApiImplTest() {
             nr = "nr",
             fnr = "03028700001"
         )
-        val initialResponse = restTemplate.exchange(
-            "$navRinasakerUrl/1/fagsak",
-            HttpMethod.PATCH,
-            initialFagsakOpprettelse.httpEntity,
-            Void::class.java
-        )
-        initialResponse.statusCode.value() shouldBe 201
-        val initialNavRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+        restTestClient.patch().uri("$navRinasakerUrl/1/fagsak")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(initialFagsakOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val initialNavRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         with(initialNavRinasak.fagsak!!) {
@@ -155,18 +156,17 @@ class RinasakerApiTest : AbstractRinasakerApiImplTest() {
             nr = "updated-nr",
             fnr = "12345678901"
         )
-        val updateResponse = restTemplate.exchange(
-            "$navRinasakerUrl/1/fagsak",
-            HttpMethod.PATCH,
-            updatedFagsakOpprettelse.httpEntity,
-            Void::class.java
-        )
-        updateResponse.statusCode.value() shouldBe 201
-        val updatedNavRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+        restTestClient.patch().uri("$navRinasakerUrl/1/fagsak")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(updatedFagsakOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val updatedNavRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         with(updatedNavRinasak.fagsak!!) {
@@ -188,12 +188,10 @@ class RinasakerApiTest : AbstractRinasakerApiImplTest() {
             nr = "nr",
             fnr = "03028700001"
         )
-        val response = restTemplate.exchange(
-            "$navRinasakerUrl/$nonExistentRinasakId/fagsak",
-            HttpMethod.PATCH,
-            fagsakOpprettelse.httpEntity,
-            Void::class.java
-        )
-        response.statusCode.value() shouldBe 404
+        restTestClient.patch().uri("$navRinasakerUrl/$nonExistentRinasakId/fagsak")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(fagsakOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(404)
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiValidationTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiValidationTest.kt
@@ -3,25 +3,26 @@ package no.nav.eux.rinasak.webapp
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.advice.MethodArgumentNotValidExceptionAdvice
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelseInvalid
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
 
 class RinasakerApiValidationTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `POST rinasaker - forespørsel, invalid fnr - 400`() {
-        val createResponse = restTemplate
-            .postForEntity<MethodArgumentNotValidExceptionAdvice.ApiError>(
-                navRinasakerUrl,
-                navRinasakOpprettelseInvalid.httpEntity
-            )
-        createResponse.statusCode.value() shouldBe 400
-        with(createResponse.body!!.errors[0]) {
+        val responseBody = restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelseInvalid)
+            .exchange()
+            .expectStatus().isEqualTo(400)
+            .expectBody(MethodArgumentNotValidExceptionAdvice.ApiError::class.java)
+            .returnResult().responseBody!!
+        with(responseBody.errors[0]) {
             rejectedValue shouldBe "invalid"
             defaultMessage shouldBe """must match "^\d{11}$""""
         }
-        with(createResponse.body!!.errors[1]) {
+        with(responseBody.errors[1]) {
             rejectedValue shouldBe "invalid"
             defaultMessage shouldBe "size must be between 11 and 11"
         }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerEnhetsnummerSlettApiTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerEnhetsnummerSlettApiTest.kt
@@ -3,48 +3,38 @@ package no.nav.eux.rinasak.webapp
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerEnhetsnummerUrl
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
 import no.nav.eux.rinasak.webapp.model.base.NavRinasak
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.http.HttpMethod.DELETE
-import org.springframework.http.HttpMethod.GET
 
 class RinasakerEnhetsnummerSlettApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `DELETE enhetsnummer - forespørsel, sletting, finn med id - 204`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val entity = restTemplate.exchange(
-            "/api/v1/rinasaker/1",
-            GET,
-            httpEntity(),
-            NavRinasak::class.java
-        )
-        entity.statusCode.value() shouldBe 200
-        val navRinasak = entity.body!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        val navRinasak = restTestClient.get().uri("/api/v1/rinasaker/1")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(NavRinasak::class.java)
+            .returnResult().responseBody!!
         navRinasak.rinasakId shouldBe 1
         navRinasak.overstyrtEnhetsnummer shouldBe "1234"
 
-        val responseEntity = restTemplate.exchange(
-            navRinasakerEnhetsnummerUrl,
-            DELETE,
-            httpEntity(),
-            Void::class.java,
-            1
-        )
-        responseEntity.statusCode.value() shouldBe 204
+        restTestClient.delete().uri(navRinasakerEnhetsnummerUrl, 1)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectStatus().isEqualTo(204)
 
-        val updatedEntity = restTemplate.exchange(
-            "/api/v1/rinasaker/1",
-            GET,
-            httpEntity(),
-            NavRinasak::class.java
-        )
-        val updatedNavRinasak = updatedEntity.body!!
+        val updatedNavRinasak = restTestClient.get().uri("/api/v1/rinasaker/1")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectBody(NavRinasak::class.java)
+            .returnResult().responseBody!!
         updatedNavRinasak.overstyrtEnhetsnummer shouldBe null
     }
 }

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerOppdateringApiTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerOppdateringApiTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.navRinasakerFinnUrl
 import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.common.uuid1
 import no.nav.eux.rinasak.webapp.common.uuid3
 import no.nav.eux.rinasak.webapp.dataset.oppdatering.navRinasakOppdatering
@@ -13,31 +14,26 @@ import no.nav.eux.rinasak.webapp.model.base.NavRinasakFinnKriterier
 import no.nav.eux.rinasak.webapp.model.base.NavRinasaker
 import no.nav.eux.rinasak.webapp.model.oppdatering.NavRinasakOppdatering
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.boot.resttestclient.postForObject
-import org.springframework.http.HttpMethod
 
 class RinasakerOppdateringApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PATCH rinasaker - forespørsel, oppdatering, finn med id - 200`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val updateResponse = restTemplate.exchange<Void>(
-            url = navRinasakerUrl,
-            method = HttpMethod.PATCH,
-            requestEntity = navRinasakOppdatering
-                .httpEntity
-        )
-        updateResponse.statusCode.value() shouldBe 201
-        val navRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        restTestClient.patch().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOppdatering)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val navRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         navRinasak.rinasakId shouldBe 1
@@ -67,27 +63,28 @@ class RinasakerOppdateringApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PATCH rinasaker - forespørsel, oppdatering kun enhetsnummer, finn med id - 200`() {
-        restTemplate.postForEntity<Void>(
-            navRinasakerUrl,
-            navRinasakOpprettelse.httpEntity
-        )
-        val updateResponse = restTemplate.exchange<Void>(
-            url = navRinasakerUrl,
-            method = HttpMethod.PATCH,
-            requestEntity = NavRinasakOppdatering(
-                rinasakId = 1,
-                overstyrtEnhetsnummer = "5678",
-                initiellFagsak = null,
-                dokumenter = null
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(navRinasakOpprettelse)
+            .exchange()
+        restTestClient.patch().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                NavRinasakOppdatering(
+                    rinasakId = 1,
+                    overstyrtEnhetsnummer = "5678",
+                    initiellFagsak = null,
+                    dokumenter = null
+                )
             )
-                .httpEntity
-        )
-        updateResponse.statusCode.value() shouldBe 201
-        val navRinasak = restTemplate
-            .postForObject<NavRinasaker>(
-                url = navRinasakerFinnUrl,
-                request = NavRinasakFinnKriterier(rinasakId = 1).httpEntity
-            )!!
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val navRinasak = restTestClient.post().uri(navRinasakerFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(NavRinasakFinnKriterier(rinasakId = 1))
+            .exchange()
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
             .navRinasaker
             .single()
         navRinasak.rinasakId shouldBe 1

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusApiTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/SedJournalstatusApiTest.kt
@@ -4,42 +4,41 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import no.nav.eux.rinasak.webapp.common.sedJournalstatuserFinnUrl
 import no.nav.eux.rinasak.webapp.common.sedJournalstatuserUrl
+import no.nav.eux.rinasak.webapp.common.token
 import no.nav.eux.rinasak.webapp.common.uuid1
 import no.nav.eux.rinasak.webapp.model.base.SedJournalstatusFinnKriterierRinasakIdTestModel
 import no.nav.eux.rinasak.webapp.model.base.SedJournalstatusFinnKriterierTestModel
 import no.nav.eux.rinasak.webapp.model.base.SedJournalstatusPutTestModel
 import no.nav.eux.rinasak.webapp.model.base.SedJournalstatuserTestModel
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.boot.resttestclient.postForObject
-import org.springframework.http.HttpMethod
-import org.springframework.http.HttpMethod.POST
 
 class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PUT sed journalstatuser - forespørsel, finn med id - 200`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "UKJENT"
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
+                    sedJournalstatus = "UKJENT"
+                )
             )
-                .httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 200
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierTestModel(
+            .exchange()
+            .expectStatus().isEqualTo(200)
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierTestModel(
                     sedId = uuid1,
                     sedVersjon = 1
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
             .single()
         sedJournalstatus.rinasakId shouldBe 1
@@ -50,26 +49,28 @@ class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PUT sed journalstatuser - forespørsel, finn med status - 200`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "UKJENT"
-            )
-                .httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 200
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierTestModel(
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
                     sedJournalstatus = "UKJENT"
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectStatus().isEqualTo(200)
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierTestModel(
+                    sedJournalstatus = "UKJENT"
+                )
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
             .single()
         sedJournalstatus.sedId shouldBe uuid1
@@ -80,26 +81,28 @@ class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PUT sed journalstatuser - forespørsel, finn med rinasakId - 200`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 3,
-                sedId = uuid1,
-                sedVersjon = 0,
-                sedJournalstatus = "MELOSYS_JOURNALFOERER"
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 3,
+                    sedId = uuid1,
+                    sedVersjon = 0,
+                    sedJournalstatus = "MELOSYS_JOURNALFOERER"
+                )
             )
-                .httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 200
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierRinasakIdTestModel(
+            .exchange()
+            .expectStatus().isEqualTo(200)
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierRinasakIdTestModel(
                     rinasakId = 3
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
             .single()
         with(sedJournalstatus) {
@@ -112,65 +115,67 @@ class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PUT sed journalstatuser - forespørsel, ikke funnet pga annen status - 200`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "UKJENT"
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
+                    sedJournalstatus = "UKJENT"
+                )
             )
-                .httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 200
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierTestModel(
+            .exchange()
+            .expectStatus().isEqualTo(200)
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierTestModel(
                     sedJournalstatus = "JOURNALFOERT"
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
         sedJournalstatus.shouldBeEmpty()
     }
 
     @Test
     fun `POST sed journalstatuser finn - forespørsel, finn uten argumenter - 400`() {
-        val response = restTemplate.exchange<Void>(
-            url = sedJournalstatuserFinnUrl,
-            method = POST,
-            requestEntity = SedJournalstatusFinnKriterierTestModel()
-                .httpEntity
-        )
-        response.statusCode.value() shouldBe 400
+        restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(SedJournalstatusFinnKriterierTestModel())
+            .exchange()
+            .expectStatus().isEqualTo(400)
     }
 
     @Test
     fun `PUT sed journalstatuser med feilmelding - forespørsel, finn med id - 200`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "FEILET_FERDIGSTILL",
-                feilmelding = "Ferdigstilling feilet: 500 Internal Server Error"
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
+                    sedJournalstatus = "FEILET_FERDIGSTILL",
+                    feilmelding = "Ferdigstilling feilet: 500 Internal Server Error"
+                )
             )
-                .httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 200
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierTestModel(
+            .exchange()
+            .expectStatus().isEqualTo(200)
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierTestModel(
                     sedId = uuid1,
                     sedVersjon = 1
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
             .single()
         sedJournalstatus.rinasakId shouldBe 1
@@ -182,27 +187,29 @@ class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PUT sed journalstatuser uten feilmelding - feilmelding er null - 200`() {
-        val createResponse = restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "UKJENT"
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
+                    sedJournalstatus = "UKJENT"
+                )
             )
-                .httpEntity
-        )
-        createResponse.statusCode.value() shouldBe 200
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierTestModel(
+            .exchange()
+            .expectStatus().isEqualTo(200)
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierTestModel(
                     sedId = uuid1,
                     sedVersjon = 1
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
             .single()
         sedJournalstatus.feilmelding shouldBe null
@@ -210,38 +217,40 @@ class SedJournalstatusApiTest : AbstractRinasakerApiImplTest() {
 
     @Test
     fun `PUT sed journalstatuser - oppdater eksisterende med feilmelding - 200`() {
-        restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "UKJENT"
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
+                    sedJournalstatus = "UKJENT"
+                )
             )
-                .httpEntity
-        )
-        restTemplate.exchange<Void>(
-            url = sedJournalstatuserUrl,
-            method = HttpMethod.PUT,
-            requestEntity = SedJournalstatusPutTestModel(
-                rinasakId = 1,
-                sedId = uuid1,
-                sedVersjon = 1,
-                sedJournalstatus = "FEILET_FERDIGSTILL",
-                feilmelding = "Ferdigstilling feilet: 500 Internal Server Error"
+            .exchange()
+        restTestClient.put().uri(sedJournalstatuserUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusPutTestModel(
+                    rinasakId = 1,
+                    sedId = uuid1,
+                    sedVersjon = 1,
+                    sedJournalstatus = "FEILET_FERDIGSTILL",
+                    feilmelding = "Ferdigstilling feilet: 500 Internal Server Error"
+                )
             )
-                .httpEntity
-        )
-        val sedJournalstatus = restTemplate
-            .postForObject<SedJournalstatuserTestModel>(
-                url = sedJournalstatuserFinnUrl,
-                request = SedJournalstatusFinnKriterierTestModel(
+            .exchange()
+        val sedJournalstatus = restTestClient.post().uri(sedJournalstatuserFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(
+                SedJournalstatusFinnKriterierTestModel(
                     sedId = uuid1,
                     sedVersjon = 1
                 )
-                    .httpEntity
-            )!!
+            )
+            .exchange()
+            .expectBody(SedJournalstatuserTestModel::class.java)
+            .returnResult().responseBody!!
             .sedJournalstatuser
             .single()
         sedJournalstatus.sedJournalstatus shouldBe "FEILET_FERDIGSTILL"

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/common/HttpEntity.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/common/HttpEntity.kt
@@ -3,23 +3,6 @@ package no.nav.eux.rinasak.webapp.common
 import com.nimbusds.jose.JOSEObjectType
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-
-fun <T> T.httpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity(this, mockOAuth2Server.httpHeaders)
-
-fun voidHttpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<Void>(mockOAuth2Server.httpHeaders)
-
-val MockOAuth2Server.httpHeaders: HttpHeaders
-    get() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.set("Authorization", "Bearer ${this.token}")
-        return headers
-    }
 
 val MockOAuth2Server.token: String
     get() = this


### PR DESCRIPTION
Replace TestRestTemplate with Spring Framework 7 RestTestClient for test HTTP calls.