### PR TITLE
chore(deps): bump parent-pom to 2.0.15, drop explicit jackson and spring-security management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 6
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 4
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "navikt/eessibasis"
+    labels:
+      - "dependencies"
+      - "automerge"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling deploy action (eessibasis namespace)'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling deploy action (eessibasis namespace)'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling deploy action (eessibasis namespace)'
         uses: nais/deploy/actions/deploy@v2
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q1'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q2'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, deploy-q1, deploy-q2]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for production'
         uses: nais/deploy/actions/deploy@v2
         env:

--- a/eux-nav-rinasak-webapp/pom.xml
+++ b/eux-nav-rinasak-webapp/pom.xml
@@ -30,6 +30,8 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <!-- Kotlin -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
@@ -40,6 +42,34 @@
         </dependency>
 
         <!-- Other -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
@@ -59,10 +89,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>tools.jackson.module</groupId>
-            <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/eux-nav-rinasak-webapp/pom.xml
+++ b/eux-nav-rinasak-webapp/pom.xml
@@ -91,6 +91,10 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
+            <groupId>tools.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.10</version>
+        <version>2.0.15</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## Changes

- Bump `no.nav.eux:parent-pom` `2.0.4` → `2.0.15`
- Remove `spring-boot-jackson2` and `jackson-module-kotlin` (now inherited from parent-pom)
- Drop `spring-security.version` property and `spring-security-bom` import (managed by parent-pom)
- Remove hardcoded `<version>` from `spring-boot-starter-security` and `spring-boot-starter-oauth2-resource-server`
- Bump `actions/checkout` v6 → v7 (Node 24)
- Add `.github/dependabot.yml` copied from eux-journalarkivar