### PR TITLE
Legg til GET /api/v1/rinasaker/nyeste for overvåkning av nye SED-er

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -91,3 +91,6 @@ spec:
         - application: {{ application.melosys-eessi.name }}
           namespace: {{ application.melosys-eessi.namespace }}
           cluster: {{ cluster.fss }}
+        - application: eux-portal-core
+          namespace: eessibasis
+          cluster: {{ cluster.gcp }}

--- a/eux-nav-rinasak-openapi/src/main/resources/static/nav-rinasak-v1.yaml
+++ b/eux-nav-rinasak-openapi/src/main/resources/static/nav-rinasak-v1.yaml
@@ -21,6 +21,8 @@ paths:
     $ref: 'rinasaker/operations_rot.yaml'
   '/api/v1/rinasaker/finn':
     $ref: 'rinasaker/operations_finn.yaml'
+  '/api/v1/rinasaker/nyeste':
+    $ref: 'rinasaker/operations_nyeste.yaml'
   '/api/v1/rinasaker/{rinasakId}':
     $ref: 'rinasaker/operations_byRinasakId.yaml'
   '/api/v1/rinasaker/{rinasakId}/overstyrtEnhetsnummer':

--- a/eux-nav-rinasak-openapi/src/main/resources/static/rinasaker/operations_nyeste.yaml
+++ b/eux-nav-rinasak-openapi/src/main/resources/static/rinasaker/operations_nyeste.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - Rinasaker
+  summary: Nyeste
+  description: >-
+    Hent de nyest opprettede Nav rinasakene med tilhørende dokumenter,
+    sortert på opprettetTidspunkt synkende. Brukes for overvåkning av
+    nylig opprettede SED-er.
+  operationId: navRinasakNyeste
+  parameters:
+    - name: antall
+      in: query
+      required: false
+      description: Maks antall rinasaker som returneres.
+      schema:
+        type: integer
+        default: 200
+        minimum: 1
+        maximum: 500
+
+  responses:
+    '200':
+      description: OK
+      content:
+        'application/json':
+          schema:
+            $ref: 'model.yaml#/NavRinasakSearchResponseType'
+    '400':
+      $ref: '../common/responses.yaml#/400'
+    '401':
+      $ref: '../common/responses.yaml#/401'
+    '403':
+      $ref: '../common/responses.yaml#/403'
+    '500':
+      $ref: '../common/responses.yaml#/500'

--- a/eux-nav-rinasak-persistence/src/main/kotlin/no/nav/eux/rinasak/persistence/NavRinasakRepository.kt
+++ b/eux-nav-rinasak-persistence/src/main/kotlin/no/nav/eux/rinasak/persistence/NavRinasakRepository.kt
@@ -4,6 +4,7 @@ import no.nav.eux.rinasak.model.entity.Dokument
 import no.nav.eux.rinasak.model.entity.Fagsak
 import no.nav.eux.rinasak.model.entity.InitiellFagsak
 import no.nav.eux.rinasak.model.entity.NavRinasak
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.*
@@ -12,6 +13,7 @@ import java.util.*
 interface NavRinasakRepository : JpaRepository<NavRinasak, UUID> {
     fun findAllByRinasakId(rinasakId: Int): List<NavRinasak>
     fun findByRinasakId(rinasakId: Int): NavRinasak?
+    fun findAllByOrderByOpprettetTidspunktDesc(pageable: Pageable): List<NavRinasak>
 }
 
 @Repository

--- a/eux-nav-rinasak-service/src/main/kotlin/no/nav/eux/rinasak/service/NavRinasakService.kt
+++ b/eux-nav-rinasak-service/src/main/kotlin/no/nav/eux/rinasak/service/NavRinasakService.kt
@@ -5,10 +5,12 @@ import no.nav.eux.rinasak.model.dto.NavRinasakFinnRequest
 import no.nav.eux.rinasak.model.dto.NavRinasakFinnResponse
 import no.nav.eux.rinasak.model.dto.NavRinasakPatch
 import no.nav.eux.rinasak.model.entity.Dokument
+import no.nav.eux.rinasak.model.entity.NavRinasak
 import no.nav.eux.rinasak.persistence.DokumentRepository
 import no.nav.eux.rinasak.persistence.FagsakRepository
 import no.nav.eux.rinasak.persistence.InitiellFagsakRepository
 import no.nav.eux.rinasak.persistence.NavRinasakRepository
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.NOT_FOUND
@@ -88,6 +90,16 @@ class NavRinasakService(
             request.rinasakId != null -> navRinasakRepository.findAllByRinasakId(request.rinasakId!!)
             else -> navRinasakRepository.findAll()
         }
+        return berik(navRinasakList)
+    }
+
+    fun finnNyesteNavRinasaker(antall: Int): List<NavRinasakFinnResponse> {
+        val navRinasakList = navRinasakRepository
+            .findAllByOrderByOpprettetTidspunktDesc(PageRequest.of(0, antall))
+        return berik(navRinasakList)
+    }
+
+    private fun berik(navRinasakList: List<NavRinasak>): List<NavRinasakFinnResponse> {
         val fagsakMap = fagsakRepository
             .findAllById(navRinasakList.map { it.navRinasakUuid })
             .associateBy { it.navRinasakUuid }

--- a/eux-nav-rinasak-webapp/src/main/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiImpl.kt
+++ b/eux-nav-rinasak-webapp/src/main/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiImpl.kt
@@ -52,6 +52,13 @@ class RinasakerApiImpl(
         .toNavRinasakSearchResponseType()
         .toOkResponseEntity()
 
+    override fun navRinasakNyeste(
+        antall: Int
+    ) = service
+        .finnNyesteNavRinasaker(antall)
+        .toNavRinasakSearchResponseType()
+        .toOkResponseEntity()
+
     override fun opprettNyttDokument(
         rinasakId: Int,
         dokumentCreateType: DokumentCreateType

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiNyesteTest.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/RinasakerApiNyesteTest.kt
@@ -1,0 +1,71 @@
+package no.nav.eux.rinasak.webapp
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.eux.rinasak.webapp.common.navRinasakerNyesteUrl
+import no.nav.eux.rinasak.webapp.common.navRinasakerUrl
+import no.nav.eux.rinasak.webapp.common.token
+import no.nav.eux.rinasak.webapp.common.uuid1
+import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelse
+import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelseEnkel2
+import no.nav.eux.rinasak.webapp.dataset.opprettelse.navRinasakOpprettelseEnkel3
+import no.nav.eux.rinasak.webapp.model.base.NavRinasaker
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+class RinasakerApiNyesteTest : AbstractRinasakerApiImplTest() {
+
+    private fun opprett(body: Any) {
+        restTestClient.post().uri(navRinasakerUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(body)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+    }
+
+    private fun hentNyeste(uri: String = navRinasakerNyesteUrl) =
+        restTestClient.get().uri(uri)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(NavRinasaker::class.java)
+            .returnResult().responseBody!!
+            .navRinasaker
+
+    @Test
+    fun `GET rinasaker nyeste - sortert nyeste foerst - 200`() {
+        opprett(navRinasakOpprettelse)
+        opprett(navRinasakOpprettelseEnkel2)
+        opprett(navRinasakOpprettelseEnkel3)
+        val navRinasaker = hentNyeste()
+        navRinasaker shouldHaveSize 3
+        navRinasaker.map { it.rinasakId } shouldContainExactly listOf(3, 2, 1)
+        with(navRinasaker.single { it.rinasakId == 1 }.dokumenter!!.single()) {
+            sedId shouldBe uuid1
+            sedType shouldBe "type"
+        }
+    }
+
+    @Test
+    fun `GET rinasaker nyeste - antall begrenser resultatet - 200`() {
+        opprett(navRinasakOpprettelse)
+        opprett(navRinasakOpprettelseEnkel2)
+        opprett(navRinasakOpprettelseEnkel3)
+        val navRinasaker = hentNyeste("$navRinasakerNyesteUrl?antall=2")
+        navRinasaker.map { it.rinasakId } shouldContainExactly listOf(3, 2)
+    }
+
+    @Test
+    fun `GET rinasaker nyeste - tom database - 200`() {
+        hentNyeste() shouldHaveSize 0
+    }
+
+    @Test
+    fun `GET rinasaker nyeste - ikke autentisert - 401`() {
+        restTestClient.get().uri(navRinasakerNyesteUrl)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isEqualTo(401)
+    }
+}

--- a/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/common/Url.kt
+++ b/eux-nav-rinasak-webapp/src/test/kotlin/no/nav/eux/rinasak/webapp/common/Url.kt
@@ -4,6 +4,8 @@ const val navRinasakerUrl = "/api/v1/rinasaker"
 
 const val navRinasakerFinnUrl = "/api/v1/rinasaker/finn"
 
+const val navRinasakerNyesteUrl = "/api/v1/rinasaker/nyeste"
+
 const val sedJournalstatuserUrl = "/api/v1/sed/journalstatuser"
 
 const val sedJournalstatuserFinnUrl = "/api/v1/sed/journalstatuser/finn"


### PR DESCRIPTION
## Hva

Nytt **read-only** endepunkt `GET /api/v1/rinasaker/nyeste?antall={n}` som henter de nyest opprettede Nav-rinasakene (med tilhørende dokumenter/SED-er), sortert på `opprettetTidspunkt` synkende. `antall` er valgfri (default 200, maks 500).

## Hvorfor

`eux-architecture-portal` skal få en ny side (**«SED-er i nEESSI»**) som overvåker SED-er som er **opprettet i nEESSI** (og dermed har en record i `eux-nav-rinasak`), men som **ennå ikke er sendt**. `eux-portal-core` poller dette endepunktet (~5s per miljø, Q1/Q2) og strømmer nye SED-er til portalen via SSE.

Eksisterende `POST /finn` krever eksakt `rinasakId` og egner seg ikke til å liste «nyeste». Dette endepunktet er additivt og gjenbruker eksisterende `NavRinasakSearchResponseType`.

## Endringer

- **OpenAPI**: `rinasaker/operations_nyeste.yaml` + path i `nav-rinasak-v1.yaml`
- **Repository**: `findAllByOrderByOpprettetTidspunktDesc(Pageable)`
- **Service**: `finnNyesteNavRinasaker(antall)`; `berik()` ekstrahert og delt med `findAllNavRinasaker`
- **Controller**: `navRinasakNyeste`
- **Test**: `RinasakerApiNyesteTest` (sortering nyeste først, `antall`-grense, tom db, 401)
- **NAIS**: inbound access-policy for `eux-portal-core` (dev-gcp) slik at portal-core kan kalle endepunktet

## Test

`RinasakerApiNyesteTest` – 4/4 grønne mot Postgres 18.

> ⚠️ **Test/PoC** – dette er del av en eksperimentell portal-funksjon. Ikke merge uten avklaring med teamet.