### PR TITLE
chore(deps): bump parent-pom 2.0.20, tomcat 11.0.24, postgresql-jdbc 42.7.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,15 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.18</version>
+        <version>2.0.20</version>
     </parent>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.24</tomcat.version>
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Endringer

Bumper avhengigheter i rot-`pom.xml`:

| Avhengighet | Fra | Til |
|---|---|---|
| `no.nav.eux:parent-pom` | 2.0.18 | **2.0.20** |
| Tomcat | (arvet) | **11.0.24** |
| PostgreSQL JDBC | (arvet) | **42.7.13** |

Tomcat og PostgreSQL JDBC hadde ingen eksplisitte versjoner — de arves fra parent-pom. Lagt til som `tomcat.version` og `postgresql.version` properties for å overstyre.

🟢 Ren dependency bump — ingen kodeendringer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>