### PR TITLE
fix(deps): faktisk overstyr postgresql 42.7.13 og tomcat 11.0.24 (CVE-2026-54291)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,32 @@
         <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Overstyrer versjoner fra importert spring-boot-dependencies BOM (property alene er no-op ved import-scope). Se navikt/eux-parent-pom#24 og #25. -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <scm>
         <connection>scm:git:https://github.com/navikt/eux-nav-rinasak.git</connection>
         <developerConnection>scm:git:https://github.com/navikt/eux-nav-rinasak.git</developerConnection>


### PR DESCRIPTION
## Problem

Bumpen i #36 var **property-basert** (`<postgresql.version>`, `<tomcat.version>`) — men det er en **no-op**. `parent-pom` importerer `spring-boot-dependencies` som BOM (`<scope>import</scope>`), og ved import-scope interpoleres versjonene med BOM-ens **egne** properties, ikke våre. Resultat: effektive versjoner sto fortsatt på **postgresql 42.7.11** (sårbar, **CVE-2026-54291**) og **tomcat-embed-* 11.0.22**.

## Løsning

Legger til eksplisitt `dependencyManagement` i rot-`pom.xml` for `org.postgresql:postgresql` og de tre `tomcat-embed-*`-artefaktene. Barnets `dependencyManagement` overstyrer den importerte BOM-en.

## Verifisert (`mvn dependency:tree`)

| Artefakt | Før | Etter |
|---|---|---|
| `org.postgresql:postgresql` | 42.7.11 | **42.7.13** ✅ |
| `tomcat-embed-core/-el/-websocket` | 11.0.22 | **11.0.24** ✅ |

Fikser **CVE-2026-54291**.

## Oppfølging

Bør sentraliseres i parent-pom slik at alle konsumenter slipper lokal overstyring:
- navikt/eux-parent-pom#25 (PostgreSQL)
- navikt/eux-parent-pom#24 (Tomcat)

Når disse er løst og tatt inn, kan denne lokale `dependencyManagement`-blokken fjernes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>