### PR TITLE
fix: close CVEs for httpcomponents and log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,54 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>ban-httpcomponents-cve</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.apache.httpcomponents.core5:httpcore5:(,5.4.3)</exclude>
+                                        <exclude>org.apache.httpcomponents.core5:httpcore5-h2:(,5.4.3)</exclude>
+                                        <exclude>org.apache.httpcomponents.client5:httpclient5:(,5.6.4)</exclude>
+                                    </excludes>
+                                    <message>httpcore5/httpcore5-h2 &lt; 5.4.3 og httpclient5 &lt; 5.6.4 er bannlyst.</message>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ban-log4j-cve</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.apache.logging.log4j:*:(,2.25.5)</exclude>
+                                    </excludes>
+                                    <message>log4j &lt; 2.25.5 er bannlyst.</message>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <scm>
         <connection>scm:git:https://github.com/navikt/eux-nav-rinasak.git</connection>
         <developerConnection>scm:git:https://github.com/navikt/eux-nav-rinasak.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <tomcat.version>11.0.24</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
         <httpcore5.version>5.4.3</httpcore5.version>
+        <log4j.version>2.25.5</log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -54,6 +55,14 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat.version}</version>
+            </dependency>
+            <!-- CVE-2026-49844 -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- CVE-2026-54399 / CVE-2026-54428 -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
     </properties>
 
     <dependencyManagement>
@@ -53,6 +54,17 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat.version}</version>
+            </dependency>
+            <!-- CVE-2026-54399 / CVE-2026-54428 -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <tomcat.version>11.0.24</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
         <httpcore5.version>5.4.3</httpcore5.version>
+        <httpclient5.version>5.6.4</httpclient5.version>
         <log4j.version>2.25.5</log4j.version>
     </properties>
 
@@ -74,6 +75,12 @@
                 <groupId>org.apache.httpcomponents.core5</groupId>
                 <artifactId>httpcore5-h2</artifactId>
                 <version>${httpcore5.version}</version>
+            </dependency>
+            <!-- CVE-2026-64607 -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Hva er gjort
- Pinner sikre versjoner i root pom.xml via dependencyManagement
- Legger til maven-enforcer-plugin med bannedDependencies for å hindre regresjon
- Leverer som separate commits per tema i én PR

## CVE-er
- CVE-2026-54399 / CVE-2026-54428 (httpcore5, httpcore5-h2)
- CVE-2026-64607 (httpclient5)
- CVE-2026-49844 (log4j)

## Før/etter
| Artefakt | Før | Etter |
|---|---:|---:|
| org.apache.httpcomponents.core5:httpcore5 | 5.4.2 | 5.4.3 |
| org.apache.httpcomponents.core5:httpcore5-h2 | 5.4.2 | 5.4.3 |
| org.apache.httpcomponents.client5:httpclient5 | 5.6.1 | 5.6.4 |
| org.apache.logging.log4j:log4j-api | 2.25.4 | 2.25.5 |
| org.apache.logging.log4j:log4j-to-slf4j | 2.25.4 | 2.25.5 |

## Verifisering
- mvn -s .github/settings.xml -Dkotlin.compiler.daemon=false validate
- mvn -s .github/settings.xml -Dkotlin.compiler.daemon=false test-compile
- dependency:tree viser kun målversjonene over
- Enforcer-regler kjører i alle moduler